### PR TITLE
docs: add @master in example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Returns the file size.
 ## Example usage
 
 ```yaml
-uses: DamianReeves/write-file-action
+uses: DamianReeves/write-file-action@master
 with:
   path: ${{ env.home}}/.bashrc
   contents: |


### PR DESCRIPTION
Looks like GitHub Actions throws an error if the version is not provided:

> The workflow is not valid ... Expected format {org}/{repo}[/path]@ref. Actual 'DamianReeves/write-file-action' Input string was not in a correct format