### PR TITLE
Updated README with new example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,43 @@ Returns the file size.
 ## Example usage
 
 ```yaml
-uses: DamianReeves/write-file-action
+uses: DamianReeves/write-file-action@v1.0
 with:
   path: ${{ env.home}}/.bashrc
   contents: |
     echo "Hello World!"
   write-mode: append
+```
+
+## Example usage with checkout, commit and push
+```yaml
+name: Overwrite some file
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Overwrite file
+        uses: "DamianReeves/write-file-action@v1.0"
+        with:
+          path: path/to/file.js
+          write-mode: overwrite
+          contents: |
+            console.log('some contents')
+            
+      - name: Commit & Push
+        uses: Andro999b/push@v1.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+          force: true
+          message: 'Overwritten by Github Actions - ${date}'
 ```


### PR DESCRIPTION
This adds the version in the example usage, and adds a second example usage.

The second example usage is more complete (its an entire action) and uses:
- checkout (actions/checkout@v3)
- overwrites a file (DamianReeves/write-file-action@v1.0)
- commits and pushes (Andro999b/push@v1.3)

No further fiddling around needed to have a file overwritten successfully.