### PR TITLE
Update action to run on Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ outputs:
     description: "The returned size"
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "package"


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12